### PR TITLE
Paginate trades by last execution

### DIFF
--- a/lib/itbit/trade.rb
+++ b/lib/itbit/trade.rb
@@ -5,11 +5,11 @@ module Itbit
       :rebates_applied, :currency2, :instrument, :rate, :currency1,
       :rebate_currency, :currency1_amount, :currency2_amount,
       :commission_currency
-    
+
     def initialize(attrs)
       attrs.each{|k, v| send("#{k.underscore}=", v)}
     end
-    
+
     %w(direction instrument currency1 currency2
     rebate_currency commission_currency).each do |attr|
       define_method("#{attr}=") do |value|
@@ -23,14 +23,14 @@ module Itbit
         instance_variable_set("@#{attr}", value.to_d)
       end
     end
-  
+
     def timestamp=(value)
       @timestamp = value.is_a?(String) ? Time.parse(value).to_i : value
     end
 
     # Lists all trades for a wallet
     # Results can be filtered and paginated by passing in these options.
-    #  wallet_id: String, defaults to Itbit.default_wallet_id 
+    #  wallet_id: String, defaults to Itbit.default_wallet_id
     #  page: Integer, starting page for pagination.
     #  per_page: Integer, how many to show per page.
     #  range_start: Integer timestamp, start showing at this date.
@@ -39,7 +39,7 @@ module Itbit
     def self.all(opts = {})
       wallet_id = opts[:wallet_id] || Itbit.default_wallet_id
       params = {}
-      %w(range_start range_end page per_page).each do |a|
+      %w(range_start range_end page per_page last_execution_id).each do |a|
         params[a.camelize(:lower)] = opts[a.to_sym].to_i if opts[a.to_sym]
       end
       response = Api.request(:get, "/wallets/#{wallet_id}/trades", params)

--- a/spec/trade_spec.rb
+++ b/spec/trade_spec.rb
@@ -28,13 +28,15 @@ describe Itbit::Trade do
       rangeStart: 0,
       rangeEnd: 100000,
       page: '1',
-      perPage: '200')
+      perPage: '200',
+      lastExecutionId: 300)
     trades = Itbit::Trade.all(
       wallet_id: 'wallet-001',
       range_start: 0,
       range_end: 100000,
       page: 1,
-      per_page: 200)
+      per_page: 200,
+      last_execution_id: 300)
     trades[:trading_history].size.should == 2
     trades[:trading_history].each{|o| o.should be_an Itbit::Trade}
   end


### PR DESCRIPTION
### Change

Add `lastExecutionId` as a parameter to paginate trades.
